### PR TITLE
feat: Add modules for rendering crontab

### DIFF
--- a/Cron/CronExpr/Type.dhall
+++ b/Cron/CronExpr/Type.dhall
@@ -1,0 +1,4 @@
+let CronExpr =
+      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/util/CronTab/package.dhall sha256:0e38ee5c60705ed2acbcd80947555abb6c2f7092c3956891b3ad4b2e2d6fef00
+
+in  { Type = CronExpr.type, default = CronExpr.default }

--- a/Cron/CronExpr/show.dhall
+++ b/Cron/CronExpr/show.dhall
@@ -1,0 +1,2 @@
+( https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/util/CronTab/package.dhall sha256:0e38ee5c60705ed2acbcd80947555abb6c2f7092c3956891b3ad4b2e2d6fef00
+).show

--- a/Cron/CronJob/Type.dhall
+++ b/Cron/CronJob/Type.dhall
@@ -1,0 +1,5 @@
+let CronExpr = ../CronExpr/Type.dhall
+
+in  { Type = { when : CronExpr.Type, what : Text, enabled : Bool }
+    , default = { when = CronExpr::{=}, enabled = True }
+    }

--- a/Cron/CronJob/show.dhall
+++ b/Cron/CronJob/show.dhall
@@ -1,0 +1,21 @@
+let Text/concatSep =
+      https://github.com/dhall-lang/dhall-lang/raw/master/Prelude/Text/concatSep sha256:e4401d69918c61b92a4c0288f7d60a6560ca99726138ed8ebc58dca2cd205e58
+
+let CronExpr = ../CronExpr/Type.dhall
+
+let CronExpr/show = ../CronExpr/show.dhall
+
+let CronJob = ./Type.dhall
+
+let show =
+        λ(job : CronJob.Type)
+      → Text/concatSep " " [ CronExpr/show job.when, job.what ]
+
+let _example =
+      let job =
+              { when = CronExpr::{=}, what = "foo", enabled = True }
+            : CronJob.Type
+
+      in assert : show job ≡ "* * * * * foo"
+
+in  show

--- a/Cron/CronTab/Type.dhall
+++ b/Cron/CronTab/Type.dhall
@@ -1,0 +1,16 @@
+let CronJob = ../CronJob/Type.dhall
+
+in  { Type =
+        { HOME : Optional Text
+        , LOGNAME : Optional Text
+        , MAILTO : Optional Text
+        , SHELL : Optional Text
+        , jobs : List CronJob.Type
+        }
+    , default =
+        { SHELL = None Text
+        , LOGNAME = None Text
+        , MAILTO = None Text
+        , HOME = None Text
+        }
+    }

--- a/Cron/CronTab/show.dhall
+++ b/Cron/CronTab/show.dhall
@@ -1,0 +1,57 @@
+let List/map =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
+
+let Text/concatSep =
+      https://github.com/dhall-lang/dhall-lang/raw/master/Prelude/Text/concatSep sha256:e4401d69918c61b92a4c0288f7d60a6560ca99726138ed8ebc58dca2cd205e58
+
+let Optional/toList =
+      https://github.com/dhall-lang/dhall-lang/raw/master/Prelude/Optional/toList sha256:390fe99619e9a25e71a253a2b33011f9e5fa26a7d990795205543d1edd72ce5b
+
+let CronJob = ../CronJob/Type.dhall
+
+let CronJob/show = ../CronJob/show.dhall
+
+let CronVars = ../CronVars.dhall
+
+let CronTab = ./Type.dhall
+
+let show =
+        λ(tab : CronTab.Type)
+      → let optsLines =
+              Optional/toList
+                Text
+                (CronVars.tryShow (toMap tab.{ HOME, LOGNAME, MAILTO, SHELL }))
+        
+        let jobLines = List/map CronJob.Type Text CronJob/show tab.jobs
+        
+        in  Text/concatSep "\n" (optsLines # jobLines)
+
+let _example =
+      let CronExpr = ../CronExpr/Type.dhall
+      
+      let tab =
+            CronTab::{
+            , HOME = Some "asdf"
+            , MAILTO = Some "foo@example.com"
+            , jobs =
+                [ CronJob::{
+                  , when = CronExpr::{ hour = "0" }
+                  , what = "happens every midnight"
+                  }
+                , CronJob::{
+                  , when = CronExpr::{ minute = "0" }
+                  , what = "happens every minute"
+                  }
+                ]
+            }
+      
+      let expected =
+            ''
+            HOME=asdf
+            MAILTO=foo@example.com
+            * 0 * * * happens every midnight
+            0 * * * * happens every minute''
+      
+      in  assert : show tab ≡ expected
+
+in  show

--- a/Cron/CronVars.dhall
+++ b/Cron/CronVars.dhall
@@ -1,0 +1,77 @@
+let Bool/not =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/Bool/not sha256:723df402df24377d8a853afed08d9d69a0a6d86e2e5b2bac8960b0d4756c7dc4
+
+let List/filter =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/List/filter sha256:8ebfede5bbfe09675f246c33eb83964880ac615c4b1be8d856076fdbc4b26ba6
+
+let List/map =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
+
+let List/null =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/v11.1.0/Prelude/List/null sha256:2338e39637e9a50d66ae1482c0ed559bbcc11e9442bfca8f8c176bbcd9c4fc80
+
+let Optional/null =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/Optional/null sha256:efc43103e49b56c5bf089db8e0365bbfc455b8a2f0dc6ee5727a3586f85969fd
+
+let Optional/default =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/v11.1.0/Prelude/Optional/default sha256:8f802473931b605422b545d7b81de20dbecb38f2ae63950c13f5381865a7f012
+
+let Text/concatSep =
+      https://github.com/dhall-lang/dhall-lang/raw/master/Prelude/Text/concatSep sha256:e4401d69918c61b92a4c0288f7d60a6560ca99726138ed8ebc58dca2cd205e58
+
+let KOptV = { mapKey : Text, mapValue : Optional Text }
+
+let KV = { mapKey : Text, mapValue : Text }
+
+let tryShow =
+        λ(map : List KOptV)
+      → let filtered =
+              List/filter
+                KOptV
+                (λ(kOv : KOptV) → Bool/not (Optional/null Text kOv.mapValue))
+                map
+        
+        let someValKVs =
+              List/map
+                KOptV
+                KV
+                (   λ(kOv : KOptV)
+                  → { mapKey = kOv.mapKey
+                    , mapValue = Optional/default Text "" kOv.mapValue
+                    }
+                )
+                filtered
+        
+        in        if Bool/not (List/null KV someValKVs)
+            
+            then  let sep = "\n"
+                  
+                  in  Some
+                        ( Text/concatSep
+                            sep
+                            ( List/map
+                                KV
+                                Text
+                                (   λ(kv : KV)
+                                  → Text/concatSep
+                                      "="
+                                      [ kv.mapKey, kv.mapValue ]
+                                )
+                                someValKVs
+                            )
+                        )
+            
+            else  None Text
+
+let show = λ(map : List KOptV) → Optional/default Text "" (tryShow map)
+
+let _example =
+      let map = toMap { FOO = Some "this_is_foo", bar = None Text }
+      
+      let expected = "FOO=this_is_foo"
+      
+      let _tryShow = assert : tryShow map ≡ Some expected
+      
+      in assert : show map ≡ expected
+
+in  { tryShow = tryShow }


### PR DESCRIPTION
Example usage:

```dhall
let CronExpr =
      https://raw.githubusercontent.com/awseward/dhall-misc/master/Cron/CronExpr/Type.dhall

let CronJob =
      https://raw.githubusercontent.com/awseward/dhall-misc/master/Cron/CronJob/Type.dhall

let CronTab =
      https://raw.githubusercontent.com/awseward/dhall-misc/master/Cron/CronTab/Type.dhall

let CronTab/show =
      https://raw.githubusercontent.com/awseward/dhall-misc/master/Cron/CronTab/show.dhall

let tab =
      CronTab::{
      , HOME = Some "asdf"
      , MAILTO = Some "foo@example.com"
      , jobs =
          [ CronJob::{
            , when = CronExpr::{ hour = "0" }
            , what = "happens every midnight"
            }
          , CronJob::{
            , when = CronExpr::{ minute = "0" }
            , what = "happens every minute"
            }
          ]
      }

in  CronTab/show tab
```