### PR TITLE
misc: Update private GitHub import funcitonality

### DIFF
--- a/GitHub/ApiVersion/Type.dhall
+++ b/GitHub/ApiVersion/Type.dhall
@@ -1,0 +1,5 @@
+let ApiVersion = < v3 | v4 >
+
+let show = λ(ghV : ApiVersion) → merge { v3 = "v3", v4 = "v4" } ghV
+
+in  { Type = ApiVersion, default = ApiVersion.v3, show = show }

--- a/GitHub/ApiVersion/show.dhall
+++ b/GitHub/ApiVersion/show.dhall
@@ -1,0 +1,3 @@
+let ApiVersion = ./Type.dhall
+
+in  λ(version : ApiVersion.Type) → merge { v3 = "v3", v4 = "v4" } version

--- a/GitHub/ImportConfig/Type.dhall
+++ b/GitHub/ImportConfig/Type.dhall
@@ -1,0 +1,9 @@
+let ApiVersion = ../ApiVersion/Type.dhall
+
+in  { Type = { token : Text, user-agent : Text, version : ApiVersion.Type }
+    , default =
+        { user-agent =
+            "dhall-misc/??? (https://github.com/awseward/dhall-misc#README)"
+        , version = ApiVersion.default
+        }
+    }

--- a/GitHub/ImportConfig/toHeaders.dhall
+++ b/GitHub/ImportConfig/toHeaders.dhall
@@ -1,0 +1,11 @@
+let ImportConfig = ./Type.dhall
+
+let ApiVersion/show = ../ApiVersion/show.dhall
+
+in    λ(conf : ImportConfig.Type)
+    → [ { header = "Authorization", value = "token ${conf.token}" }
+      , { header = "Accept"
+        , value = "application/vnd.github.${ApiVersion/show conf.version}.raw"
+        }
+      , { header = "User-Agent", value = conf.user-agent }
+      ]

--- a/GitHub/privateHeaders.dhall
+++ b/GitHub/privateHeaders.dhall
@@ -1,0 +1,2 @@
+  λ(token : Text)
+→ ./ImportConfig/toHeaders.dhall (./ImportConfig/Type.dhall)::{ token = token }

--- a/privateGitHubFileHeaders.dhall
+++ b/privateGitHubFileHeaders.dhall
@@ -1,5 +1,1 @@
-  λ(token : Text)
-→ [ { header = "Authorization", value = "token ${token}" }
-  , { header = "Accept", value = "application/vnd.github.v3.raw" }
-  , { header = "User-Agent", value = "DhallImportsCustomHeadersTest" }
-  ]
+"UNSUPPORTED: Prefer .../GitHub/privateHeaders.dhall"


### PR DESCRIPTION
Usage looks like this:

```sh
GITHUB_TOKEN=foo dhall <<< 'https://raw.githubusercontent.com/awseward/dhall-misc/c92e033f41bc5dbe4d776c10e36351f6f594be45/GitHub/privateHeaders.dhall env:GITHUB_TOKEN as Text'
```

yields:
```dhall
[ { header = "Authorization", value = "token foo" }
, { header = "Accept", value = "application/vnd.github.v3.raw" }
, { header = "User-Agent"
  , value = "dhall-misc/??? (https://github.com/awseward/dhall-misc#README)"
  }
]
```

Also, break `privateGitHubFileHeaders.dhall`, but leave a Text value
behind pointing to new location.