### PR TITLE
Consolidate extension of Prelude JSON

### DIFF
--- a/actions-catalog/.util/template/Inputs/toJSON.dhall
+++ b/actions-catalog/.util/template/Inputs/toJSON.dhall
@@ -2,7 +2,7 @@ let imports = ../../../imports.dhall
 
 let Prelude = imports.Prelude
 
-let JSON = Prelude.JSON
+let JSON = imports.JSON
 
 let Map = Prelude.Map
 
@@ -10,6 +10,15 @@ let Inputs = ./Type.dhall
 
 let toJSON
     : Inputs → Map.Type Text JSON.Type
-    = λ(inputs : Inputs) → toMap {=} : Map.Type Text JSON.Type
+    = λ(inputs : Inputs) →
+        let j = JSON
+
+        in  toMap
+              { _example1 = j.null
+              , _example2 =
+                  j.string "inputs.something, but not in a literal like this"
+              , _example3 =
+                  j.stringOpt (Some "j here is an extendsion on Prelude.JSON")
+              }
 
 in  toJSON

--- a/actions-catalog/actions/cache/Inputs/toJSON.dhall
+++ b/actions-catalog/actions/cache/Inputs/toJSON.dhall
@@ -2,7 +2,7 @@ let imports = ../../../imports.dhall
 
 let Prelude = imports.Prelude
 
-let JSON = Prelude.JSON
+let JSON = imports.JSON
 
 let Map = Prelude.Map
 
@@ -11,14 +11,7 @@ let Inputs = ./Type.dhall
 let toJSON
     : Inputs → Map.Type Text JSON.Type
     = λ(inputs : Inputs) →
-        let j =
-              let opt =
-                    λ(a : Type) →
-                    λ(f : a → JSON.Type) →
-                    λ(x : Optional a) →
-                      merge { None = JSON.null, Some = f } x
-
-              in  JSON ⫽ { stringOpt = opt Text JSON.string }
+        let j = JSON
 
         in  toMap
               { path = j.string inputs.path

--- a/actions-catalog/actions/checkout/Inputs/toJSON.dhall
+++ b/actions-catalog/actions/checkout/Inputs/toJSON.dhall
@@ -1,28 +1,15 @@
 let imports = ../../../imports.dhall
 
-let Prelude = imports.Prelude
+let JSON = imports.JSON
 
-let JSON = Prelude.JSON
-
-let Map = Prelude.Map
+let Map = imports.Prelude.Map
 
 let Inputs = ./Type.dhall
 
 let toJSON
     : Inputs → Map.Type Text JSON.Type
     = λ(inputs : Inputs) →
-        let j =
-              let opt =
-                    λ(a : Type) →
-                    λ(f : a → JSON.Type) →
-                    λ(x : Optional a) →
-                      merge { None = JSON.null, Some = f } x
-
-              in    JSON
-                  ⫽ { boolOpt = opt Bool JSON.bool
-                    , naturalOpt = opt Natural JSON.natural
-                    , stringOpt = opt Text JSON.string
-                    }
+        let j = JSON
 
         in  toMap
               { repository = j.stringOpt inputs.repository

--- a/actions-catalog/actions/create-release/Inputs/toJSON.dhall
+++ b/actions-catalog/actions/create-release/Inputs/toJSON.dhall
@@ -2,7 +2,7 @@ let imports = ../../../imports.dhall
 
 let Prelude = imports.Prelude
 
-let JSON = Prelude.JSON
+let JSON = imports.JSON
 
 let Map = Prelude.Map
 
@@ -13,17 +13,7 @@ let Body = ./Body.dhall
 let toJSON
     : Inputs → Map.Type Text JSON.Type
     = λ(inputs : Inputs) →
-        let j =
-              let opt =
-                    λ(a : Type) →
-                    λ(f : a → JSON.Type) →
-                    λ(x : Optional a) →
-                      merge { None = JSON.null, Some = f } x
-
-              in    JSON
-                  ⫽ { boolOpt = opt Bool JSON.bool
-                    , stringOpt = opt Text JSON.string
-                    }
+        let j = JSON
 
         let Body/toJSON =
               λ(body : Body) →

--- a/actions-catalog/brpaz/hadolint-action/Inputs/toJSON.dhall
+++ b/actions-catalog/brpaz/hadolint-action/Inputs/toJSON.dhall
@@ -1,19 +1,7 @@
 let imports = ../../../imports.dhall
 
-let Prelude = imports.Prelude
-
-let JSON = Prelude.JSON
+let JSON = imports.JSON
 
 let Inputs = ./Type.dhall
 
-in  λ(inputs : Inputs) →
-      let j =
-            let opt =
-                  λ(a : Type) →
-                  λ(f : a → JSON.Type) →
-                  λ(x : Optional a) →
-                    merge { None = JSON.null, Some = f } x
-
-            in  JSON ⫽ { stringOpt = opt Text JSON.string }
-
-      in  toMap { dockerfile = j.stringOpt inputs.dockerfile }
+in  λ(inputs : Inputs) → toMap { dockerfile = JSON.stringOpt inputs.dockerfile }

--- a/actions-catalog/imports.dhall
+++ b/actions-catalog/imports.dhall
@@ -1,4 +1,23 @@
-{ GHA = ../GHA/package.dhall
-, Prelude =
-    https://raw.githubusercontent.com/dhall-lang/dhall-lang/v20.0.0/Prelude/package.dhall sha256:21754b84b493b98682e73f64d9d57b18e1ca36a118b81b33d0a243de8455814b
-}
+let Prelude =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/v20.0.0/Prelude/package.dhall sha256:21754b84b493b98682e73f64d9d57b18e1ca36a118b81b33d0a243de8455814b
+
+let JSON = Prelude.JSON
+
+let JSON/extended =
+      let opt =
+            λ(a : Type) →
+            λ(f : a → JSON.Type) →
+            λ(x : Optional a) →
+              merge { None = JSON.null, Some = f } x
+
+      in    JSON
+          ⫽ { boolOpt = opt Bool JSON.bool
+            , doubleOpt = opt Double JSON.double
+            , integerOpt = opt Integer JSON.integer
+            , naturalOpt = opt Natural JSON.natural
+            , numberOpt = opt Double JSON.number
+            , opt
+            , stringOpt = opt Text JSON.string
+            }
+
+in  { GHA = ../GHA/package.dhall, JSON = JSON/extended, Prelude }

--- a/actions-catalog/jiro4989/setup-nim-action/Inputs/toJSON.dhall
+++ b/actions-catalog/jiro4989/setup-nim-action/Inputs/toJSON.dhall
@@ -2,7 +2,7 @@ let imports = ../../../imports.dhall
 
 let Prelude = imports.Prelude
 
-let JSON = Prelude.JSON
+let JSON = imports.JSON
 
 let Map = Prelude.Map
 
@@ -11,17 +11,7 @@ let Inputs = ./Type.dhall
 let toJSON
     : Inputs → Map.Type Text JSON.Type
     = λ(inputs : Inputs) →
-        let j =
-              let opt =
-                    λ(a : Type) →
-                    λ(f : a → JSON.Type) →
-                    λ(x : Optional a) →
-                      merge { None = JSON.null, Some = f } x
-
-              in    JSON
-                  ⫽ { boolOpt = opt Bool JSON.bool
-                    , stringOpt = opt Text JSON.string
-                    }
+        let j = JSON
 
         in  toMap
               { nim-version = j.stringOpt inputs.nim-version

--- a/actions-catalog/mislav/bump-homebrew-formula-action/Inputs/toJSON.dhall
+++ b/actions-catalog/mislav/bump-homebrew-formula-action/Inputs/toJSON.dhall
@@ -1,20 +1,11 @@
 let imports = ../../../imports.dhall
 
-let Prelude = imports.Prelude
-
-let JSON = Prelude.JSON
+let JSON = imports.JSON
 
 let Inputs = ./Type.dhall
 
 in  λ(inputs : Inputs) →
-      let j =
-            let opt =
-                  λ(a : Type) →
-                  λ(f : a → JSON.Type) →
-                  λ(x : Optional a) →
-                    merge { None = JSON.null, Some = f } x
-
-            in  JSON ⫽ { stringOpt = opt Text JSON.string }
+      let j = JSON
 
       in  toMap
             { base-branch = j.stringOpt inputs.base-branch


### PR DESCRIPTION
I've ommitted the following -- I don't foresee a use for them, really:

- `arrayOpt = opt (List JSON) JSON.array`

  Also, it just doesn't seem like it would ever really be all that
  valuable to be working with a value of type `Optional (List JSON)` in
  the first place...

  Better in most cases, I think, to just have an empty `List JSON`
  instead of `None (List JSON)`.

- `objectOpt = opt (List { mapKey : Text, mapValue : JSON.Type }) JSON.object`

  Like above, I think just better to have an empty `List {…}` than to
  have a `None (List {…})`.