### PR TITLE
Update gh-actions-dhall version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: awseward/gh-actions-dhall@0.2.7
+      - uses: awseward/gh-actions-dhall@0.2.9
         with:
           dhallVersion: 1.37.1


### PR DESCRIPTION
This check should run a LOT faster now.