### PR TITLE
Add a dummy job to tag on push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  - push
+branches:
+  - master
+jobs:
+  dhall:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          #!/usr/bin/env bash
+
+          set -euo pipefail
+
+          readonly tag_name="$(date -u +%Y%m%d%H%M%S)"
+
+          echo git config user.name 'github-actions'
+          echo git config user.email 'github-actions@github.com'
+          echo git tag "${tag_name}"
+          echo git push origin "${tag_name}"


### PR DESCRIPTION
The intent is so that this doesn't run on every single commit, just the latest when a PR gets merged...