### PR TITLE
Get better typing on Type/default

### DIFF
--- a/actions-catalog/.util/Input/Type.dhall
+++ b/actions-catalog/.util/Input/Type.dhall
@@ -2,7 +2,4 @@ let imports = ../../imports.dhall
 
 let JSON = imports.JSON
 
-in  { default : Optional JSON.Type
-    , description : Text
-    , required : Optional Bool
-    }
+in  { default : Optional JSON.Type, required : Optional Bool }

--- a/actions-catalog/.util/Inputs/optionalOnly.dhall
+++ b/actions-catalog/.util/Inputs/optionalOnly.dhall
@@ -8,7 +8,9 @@ let Inputs/Type = ./Type.dhall
 
 let optionalOnly
     : Inputs/Type → Inputs/Type
-    = let f = λ(i : Input.Type) → if Input.required i then False else True
+    = let compose = imports.Prelude.Function.compose Input.Type Bool Bool
+
+      let f = compose Input.required imports.Prelude.Bool.not
 
       in  Map.filter Text Input.Type f
 

--- a/actions-catalog/.util/action.yml.dhall
+++ b/actions-catalog/.util/action.yml.dhall
@@ -4,10 +4,6 @@ let Map =
 let JSON =
       https://prelude.dhall-lang.org/v20.0.0/JSON/package.dhall sha256:b7dfd33b1a313c0518c637c3b59da8526aa8020dbe125f347edbf895331dbeca
 
-let Input =
-      { default : Optional JSON.Type
-      , description : Text
-      , required : Optional Bool
-      }
+let Input = { default : Optional JSON.Type, required : Optional Bool }
 
 in  { inputs : Map.Type Text Input }

--- a/actions-catalog/.util/fmtInputsDefault.dhall
+++ b/actions-catalog/.util/fmtInputsDefault.dhall
@@ -14,8 +14,25 @@ let Input = ./Input/package.dhall
 
 let Inputs = ./Inputs/package.dhall
 
-let allNull
-    : Inputs.Type → Map.Type Text JSON.Type
-    = Map.map Text Input.Type JSON.Type (λ(_ : Input.Type) → JSON.null)
+let mapNone
+    : Inputs.Type → Map.Type Text (Optional JSON.Type)
+    = let f = λ(_ : Input.Type) → None JSON.Type
 
-in  λ(inputs : Inputs.Type) → allNull (Inputs.optionalOnly inputs)
+      in  Map.map Text Input.Type (Optional JSON.Type) f
+
+let mapDefaults
+    : Inputs.Type → Map.Type Text (Optional JSON.Type)
+    = let f = λ(i : Input.Type) → i.default
+
+      in  Map.map Text Input.Type (Optional JSON.Type) f
+
+let fmtInputsDefault
+    : Inputs.Type → List (Map.Type Text (Optional JSON.Type))
+    = λ(inputs : Inputs.Type) →
+        let optionalOnly = Inputs.optionalOnly inputs
+
+        in  [ mapNone optionalOnly ] # [ mapDefaults optionalOnly ]
+
+let _ = assert : "TODO: write test(s)" ≡ "TODO: write test(s)"
+
+in  fmtInputsDefault

--- a/actions-catalog/.util/fmtInputsDefault2.dhall
+++ b/actions-catalog/.util/fmtInputsDefault2.dhall
@@ -1,0 +1,28 @@
+{-
+
+TODO: Give this a better name than `fmtInputsDefault2`.
+
+-}
+let imports = ../imports.dhall
+
+let Map = imports.Map
+
+let JSON = imports.JSON
+
+let Input = ./Input/package.dhall
+
+let Inputs = ./Inputs/package.dhall
+
+let mapNone
+    : Inputs.Type → Map.Type Text JSON.Type
+    = let f = λ(_ : Input.Type) → JSON.null
+
+      in  Map.map Text Input.Type JSON.Type f
+
+let fmtInputsDefault2
+    : Inputs.Type → Map.Type Text JSON.Type
+    = λ(inputs : Inputs.Type) → mapNone (Inputs.optionalOnly inputs)
+
+let _ = assert : "TODO: write test(s)" ≡ "TODO: write test(s)"
+
+in  fmtInputsDefault2

--- a/actions-catalog/.util/fmtInputsType.dhall
+++ b/actions-catalog/.util/fmtInputsType.dhall
@@ -1,9 +1,3 @@
-{-
-
-TODO: Change this so that maybe we can actually get a few `Optional a` instead
-      of just all `Optional <>`.
-
--} -----
 let imports = ../imports.dhall
 
 let Map = imports.Map
@@ -17,20 +11,12 @@ let Inputs = ./Inputs/package.dhall
 let fmtInputsType
     : Inputs.Type → Map.Type Text JSON.Type
     = λ(inputs : Inputs.Type) →
-        let requiredMap =
-              let filtered = Inputs.requiredOnly inputs
+        let filtered = Inputs.requiredOnly inputs
 
-              let f = λ(input : Input.Type) → JSON.string ""
+        let f = λ(input : Input.Type) → JSON.string ""
 
-              in  Map.map Text Input.Type JSON.Type f filtered
+        in  Map.map Text Input.Type JSON.Type f filtered
 
-        let notRequiredMap =
-              let filtered = Inputs.optionalOnly inputs
-
-              let f = λ(input : Input.Type) → JSON.null
-
-              in  Map.map Text Input.Type JSON.Type f filtered
-
-        in  requiredMap # notRequiredMap
+let _ = assert : "TODO: write test(s)" ≡ "TODO: write test(s)"
 
 in  fmtInputsType


### PR DESCRIPTION
With the example of lukka/run-cmake:

Type
---

```
{ buildDirectory : Optional Text
, buildWithCMake : Optional Bool
, buildWithCMakeArgs : Optional Text
, cmakeAppendedArgs : Optional Text
, cmakeBuildType : Optional Text
, cmakeGenerator : Optional Text
, cmakeListsOrSettingsJson : Text
, cmakeListsTxtPath : Optional Text
, cmakeSettingsJsonPath : Optional Text
, cmakeToolchainPath : Optional Text
, cmakeWrapperCommand : Optional Text
, configurationRegexFilter : Text
, ninjaDownloadUrl : Optional Text
, ninjaPath : Optional Text
, useShell : Optional Bool
, useVcpkgToolchainFile : Optional Bool
, vcpkgTriplet : Optional <>
}
```

default
---

```
{ buildDirectory = None Text
, buildWithCMake = None Bool
, buildWithCMakeArgs = None Text
, cmakeAppendedArgs = None Text
, cmakeBuildType = None Text
, cmakeGenerator = None Text
, cmakeListsTxtPath = None Text
, cmakeSettingsJsonPath = None Text
, cmakeToolchainPath = None Text
, cmakeWrapperCommand = None Text
, ninjaDownloadUrl = None Text
, ninjaPath = None Text
, useShell = None Bool
, useVcpkgToolchainFile = None Bool
, vcpkgTriplet = None <>
}
```

---

Inputs which are not required but also have no default declared in
action.yml don't really give us anything to infer a type from, so they
just get `Optional <>`/`None <>`.